### PR TITLE
Add initial test setup with unit and integration examples

### DIFF
--- a/__tests__/integration/chatApi.test.js
+++ b/__tests__/integration/chatApi.test.js
@@ -1,0 +1,27 @@
+import handler from '../../pages/api/chat.js'
+
+jest.mock('openai', () => {
+  return {
+    default: jest.fn().mockImplementation(() => ({
+      chat: {
+        completions: {
+          create: jest.fn().mockResolvedValue((async function * () {
+            yield { choices: [{ delta: { content: 'hi' } }] }
+          })())
+        }
+      }
+    }))
+  }
+})
+
+describe('chat API', () => {
+  test('streams response from OpenAI', async () => {
+    const req = new Request('http://localhost/api/chat', {
+      method: 'POST',
+      body: JSON.stringify({ prompt: 'Hello', conversationId: '123' })
+    })
+    const res = await handler(req)
+    const text = await res.text()
+    expect(text).toBe('hi')
+  })
+})

--- a/components/__tests__/AutoGrowingInput.test.jsx
+++ b/components/__tests__/AutoGrowingInput.test.jsx
@@ -1,0 +1,24 @@
+import { render, fireEvent } from '@testing-library/react'
+import AutoGrowingInput from '../AutoGrowingInput'
+
+describe('AutoGrowingInput', () => {
+  test('calls onSubmit when Enter is pressed without Shift', () => {
+    const onSubmit = jest.fn()
+    const { getByPlaceholderText } = render(
+      <AutoGrowingInput value="" onChange={() => {}} onSubmit={onSubmit} placeholder="Type..." />
+    )
+    const textarea = getByPlaceholderText('Type...')
+    fireEvent.keyDown(textarea, { key: 'Enter', shiftKey: false, preventDefault: () => {} })
+    expect(onSubmit).toHaveBeenCalled()
+  })
+
+  test('does not call onSubmit when Enter is pressed with Shift', () => {
+    const onSubmit = jest.fn()
+    const { getByPlaceholderText } = render(
+      <AutoGrowingInput value="" onChange={() => {}} onSubmit={onSubmit} placeholder="Type..." />
+    )
+    const textarea = getByPlaceholderText('Type...')
+    fireEvent.keyDown(textarea, { key: 'Enter', shiftKey: true, preventDefault: () => {} })
+    expect(onSubmit).not.toHaveBeenCalled()
+  })
+})

--- a/functions/__tests__/clx.test.js
+++ b/functions/__tests__/clx.test.js
@@ -1,0 +1,7 @@
+import clx from '../clx'
+
+describe('clx', () => {
+  test('joins class names with spaces', () => {
+    expect(clx('a', 'b', 'c')).toBe('a b c')
+  })
+})

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,12 @@
+const nextJest = require('next/jest')
+
+const createJestConfig = nextJest({
+  dir: './'
+})
+
+const customJestConfig = {
+  testEnvironment: 'jsdom',
+  setupFilesAfterEnv: ['<rootDir>/jest.setup.js']
+}
+
+module.exports = createJestConfig(customJestConfig)

--- a/jest.integration.config.js
+++ b/jest.integration.config.js
@@ -1,0 +1,10 @@
+const nextJest = require('next/jest')
+
+const createJestConfig = nextJest({
+  dir: './'
+})
+
+module.exports = createJestConfig({
+  testEnvironment: 'node',
+  testMatch: ['**/__tests__/integration/**/*.test.js']
+})

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom'

--- a/package.json
+++ b/package.json
@@ -10,7 +10,9 @@
   "scripts": {
     "build": "next build",
     "dev": "nodemon ./server/init.js",
-    "start": "NODE_ENV=production node ./server/init.js"
+    "start": "NODE_ENV=production node ./server/init.js",
+    "test": "jest",
+    "test:integration": "jest --config jest.integration.config.js"
   },
   "dependencies": {
     "next": "^14.2.4",
@@ -25,6 +27,9 @@
   "devDependencies": {
     "nodemon": "^3.1.4",
     "sass": "^1.77.6",
-    "standard": "^17.1.0"
+    "standard": "^17.1.0",
+    "jest": "^29.7.0",
+    "@testing-library/react": "^14.1.2",
+    "@testing-library/jest-dom": "^6.4.6"
   }
 }


### PR DESCRIPTION
## Summary
- add npm scripts for unit and integration tests
- configure Jest for component and API testing
- create sample unit tests for `clx` and `AutoGrowingInput`
- add integration test for chat API with mocked OpenAI

## Testing
- `npm test` *(fails: jest: not found)*
- `npm run test:integration` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68afa27aa90c832fbc7fcb502ba73430